### PR TITLE
fix(xdelta3): use static type sizes to allow cross-compile

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,17 +11,11 @@ fn main() {
         ("SHELL_TESTS".to_string(), "0".to_string()),
         ("XD3_ENCODER".to_string(), "0".to_string()),
         ("XD3_USE_LARGEFILE64".to_string(), "1".to_string()),
+        ("SIZEOF_SIZE_T".to_string(), "4".to_string()),
+        ("SIZEOF_UNSIGNED_INT".to_string(), "4".to_string()),
+        ("SIZEOF_UNSIGNED_LONG".to_string(), "4".to_string()),
+        ("SIZEOF_UNSIGNED_LONG_LONG".to_string(), "8".to_string()),
     ];
-
-    for i in &[
-        "size_t",
-        "unsigned int",
-        "unsigned long",
-        "unsigned long long",
-    ] {
-        let def_name = format!("SIZEOF_{}", i.to_uppercase().replace(' ', "_"));
-        defs.push((def_name, check_native_size(i)));
-    }
 
     {
         let mut build = cc::Build::new();
@@ -53,51 +47,4 @@ fn main() {
             )
             .expect("Failed to write bindings");
     }
-}
-
-fn check_native_size(name: &str) -> String {
-    use rand::Rng;
-    use std::fs::remove_file;
-    use std::io::Write;
-
-    let builder = cc::Build::new();
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    let compiler = builder.get_compiler();
-    let mut compile = std::process::Command::new(compiler.path().as_os_str());
-    let test_code = format!("#include <stdint.h>\n#include <stdio.h>\nint main() {{printf(\"%lu\", sizeof({})); return 0;}}\n", name);
-    // didn't use tempfile since tempfile was having issues on Windows
-    let mut rng = rand::thread_rng();
-    let test_binary_fn = format!("{}/test-{}", out_dir, rng.gen::<i32>());
-
-    #[cfg(windows)]
-    let test_binary_fn = format!("{}.exe", test_binary_fn);
-
-    let test_source_fn = format!("{}/test-{:x}.c", out_dir, rng.gen::<i32>());
-    let mut test_source =
-        std::fs::File::create(&test_source_fn).expect("Error creating test compile files");
-
-    compile.args(compiler.args()).current_dir(out_dir);
-    if compiler.is_like_msvc() {
-        compile.args([&test_source_fn, &format!("/Fe{}", test_binary_fn)]);
-    } else {
-        compile.args([&test_source_fn, "-o", &test_binary_fn]);
-    }
-    test_source
-        .write_all(test_code.as_bytes())
-        .expect("Error writing test compile files");
-    drop(test_source); // close the source file, otherwise there will be problems on Windows
-    for (a, b) in compiler.env().iter() {
-        compile.env(a, b);
-    }
-    compile.output().expect("Error compiling test source");
-    remove_file(test_source_fn).ok();
-
-    compile = std::process::Command::new(&test_binary_fn);
-    let output = compile
-        .output()
-        .expect("Error executing test binary")
-        .stdout;
-    let output = String::from_utf8(output).expect("Error converting Unicode sequence");
-    remove_file(test_binary_fn).ok();
-    output
 }


### PR DESCRIPTION
This change updates the bindings for xdelta3 to use static type sizes instead of dynamically determining the size based on the compiler used. This is necessary to allow cross-compilation, as `check_native_size()` will fail to run the test binary to determine the appropriate type sizes.